### PR TITLE
Add other methods for states requests and fix small issues

### DIFF
--- a/api/v1/views/__init__.py
+++ b/api/v1/views/__init__.py
@@ -8,3 +8,4 @@ from flask import Blueprint, Flask, abort, render_template
 app_views = Blueprint('app_views', __name__, url_prefix="/api/v1")
 
 from api.v1.views.index import *
+from api.v1.views.states import *

--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -6,21 +6,32 @@ with GET, POST, PUT and DELETE
 from models import storage
 from models.state import State
 from api.v1.views import app_views
-from flask import abort
+from flask import abort, jsonify, request
 
 
-@app_views.route("/states")
+@app_views.route(
+        "/states",
+        methods=["GET"]
+    )
 def all_state_objects_in_JSON():
     """
     Returns all State objects in 'storage',
     in dictionary form,
     which is JSON serializable.
     """
-    return storage.all(State)
+    return jsonify(
+        {
+            key: state.to_dict()
+            for key, state in
+            storage.all(State).items()
+        }
+    )
 
-
-@app_views.route("/states/<str:state_id>")
-def all_state_objects_in_JSON(state_id: str):
+@app_views.route(
+        "/states/<state_id>",
+        methods=["GET"]
+    )
+def get_state_in_JSON(state_id):
     """
     Returns the State with the 'state_id'
     argument and route in 'storage',
@@ -29,9 +40,86 @@ def all_state_objects_in_JSON(state_id: str):
 
     Raises 404 otherwise.
     """
-    result = storage.get(State, state_id)
+    result = storage.get(State, f"State.{state_id}")
 
     if result is None:
         abort(404)
 
-    return result.to_dict()
+    print(result.to_dict())
+
+    return jsonify(result.to_dict())
+
+
+@app_views.route(
+        "/states/<state_id>",
+        methods=["DELETE"]
+    )
+def delete_state_by_id(state_id):
+    """
+    Deletes State object with 'state_id' as its 'id'
+    field/column value (let's call it 'target')
+    from 'storage.all' dictionary, by calling storage.delete(<target>)
+
+    Returns ({}, 200) if successful,
+    404 if 'target' doesn't exist.
+    """
+    target = storage.get(State, state_id)
+
+    if target is None:
+        abort(404)
+    storage.delete(target)
+
+    return jsonify({}), 200
+
+
+@app_views.route(
+        "/states/",
+        methods=["POST"]
+    )
+def post_state_by_id():
+    """
+    Creates new State object based on
+    JSON input and the State and BaseModel
+    constructors (these constructors are in
+    <project root>/models/).
+
+    If the input provided isn't valid JSON
+    or if the JSON provided has no 'name' key,
+    this function calls 'flask.abort(400)',
+    with a message of what went wrong:
+    either "Not a JSON" or "Missing name".
+    """
+    new_state_in_JSON = request.get_json()
+    # Automatically calls 400 when POST request
+    # has invalid JSON.
+    # So, this new state object MUST be valid
+    # (if the keys are also valid):
+    if 'name' not in new_state_in_JSON:
+        abort(400, "Missing name")
+
+    new_state = State(**new_state_in_JSON)
+    storage.new(new_state)
+    return new_state, 201
+
+
+@app_views.route(
+    "/states/<state_id>",
+    methods=["PUT"])
+def put_state_in_JSON(state_id):
+    """
+    Overrides State object with id in PUT request
+    (??)
+    """
+    if f"State.{state_id}" not in storage.all(State):
+        abort(404)
+
+    new_state_info = request.get_json()
+
+    state = storage.get(State, state_id)
+    # state acts like a "pointer" to the State object,
+    # so it doesn't need to be put back
+    # in the storage.
+    if 'name' in new_state_info:
+        state.name = new_state_info['name']
+    
+    return jsonify(state.to_dict()), 200

--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -123,8 +123,18 @@ def post_state_in_JSON():
     methods=["PUT"])
 def put_state_in_JSON(state_id):
     """
-    Overrides State object with id in PUT request
-    (??)
+    Overrides State object's fields
+    except for 'id', 'created_at' and 'updated_at',
+    where the object's id is 'state_id',
+    with the json attributes provided in the
+    PUT request.
+
+    If the state with 'state_id' as its 'id'
+    doesn't exist, this function calls
+    abort(404).
+
+    Otherwise, this function returns the JSON
+    format of the new state with code 200.
     """
     if storage.get(State, state_id) is None:
         abort(404)

--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -1,4 +1,8 @@
 #!/usr/bin/python3
+"""
+file for "/api/v1/states" API
+with GET, POST, PUT and DELETE
+"""
 from models import storage
 from models.state import State
 from api.v1.views import app_views
@@ -7,6 +11,11 @@ from flask import abort
 
 @app_views.route("/states")
 def all_state_objects_in_JSON():
+    """
+    Returns all State objects in 'storage',
+    in dictionary form,
+    which is JSON serializable.
+    """
     return storage.all(State)
 
 
@@ -14,8 +23,9 @@ def all_state_objects_in_JSON():
 def all_state_objects_in_JSON(state_id: str):
     """
     Returns the State with the 'state_id'
-    argument and route in 'storage'
-    if the State object exists,
+    argument and route in 'storage',
+    in its JSON-serializable dict form,
+    if the State object exists.
 
     Raises 404 otherwise.
     """

--- a/api/v1/views/states.py
+++ b/api/v1/views/states.py
@@ -49,8 +49,6 @@ def get_state_in_JSON(state_id):
     if result is None:
         abort(404)
 
-    print(result.to_dict())
-
     return jsonify(result.to_dict())
 
 


### PR DESCRIPTION
I found out we're supposed to save the changed in the 'storage' variable so that the changes are reflected in the database and in the json file.
The documentation is now better and more accurate.
In the Holberton intranet example, the curl requests finish with a slash, but in our code, they didn't. So, I added 'strict_slashes=False', and that solved the issue.
Finally, there was a print statement that I will remove right after posting this pull request.

Also, don't worry if by trying to delete a State, you get an error from sqlalchemy. That's totally normal, it just means that the State is linked to cities and those cities can't have a null connection with the State. Gabriel told me to just ignore it, since the exercises don't check that.